### PR TITLE
fix(form): height issue between listbox and text input fields

### DIFF
--- a/src/components/form-field/text-input/text-input.tsx
+++ b/src/components/form-field/text-input/text-input.tsx
@@ -62,7 +62,7 @@ export const TextInput = ({
         onClick={autoSelect ? handleAutoSelection : undefined}
         type={type}
         className={classNames(
-          "paragraph-100 block w-full rounded border border-neutral-400 py-2 pl-3 pr-2 text-neutral-800 placeholder:text-neutral-600 focus:outline-none",
+          "paragraph-100 block w-full h-8 rounded border border-neutral-400 py-2 pl-3 pr-2 text-neutral-800 placeholder:text-neutral-600 focus:outline-none",
           LeftIcon && "pl-9",
           readOnly && "bg-neutral-100",
           disabled && "cursor-not-allowed bg-neutral-100 text-neutral-600",


### PR DESCRIPTION
Fixed a small issue with different heights between text input fields and list boxes:

<img width="708" alt="CleanShot 2023-05-24 at 16 47 36@2x" src="https://github.com/abusix/hailstorm/assets/4981006/e3cf6710-f747-49c4-8ddb-ee60c8012d6a">

Before:
<img width="709" alt="grafik" src="https://github.com/abusix/hailstorm/assets/4981006/1defd7c7-8644-4d99-96c8-db7acaa1ede4">
