### PR TITLE
Pla 321 integrate the new hailstorm npm package into frontend v2

### DIFF
--- a/src/components/alert/index.ts
+++ b/src/components/alert/index.ts
@@ -1,1 +1,1 @@
-export { Alert } from "./alert";
+export { Alert, AlertIntent } from "./alert";

--- a/src/components/form-field/form-field-group.tsx
+++ b/src/components/form-field/form-field-group.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-interface FormFieldAttachedFieldsGroupProps {
+export interface FormFieldGroupProps {
   children: React.ReactNode;
 }
 
-export const FormFieldGroup = ({ children }: FormFieldAttachedFieldsGroupProps) => {
+export const FormFieldGroup = ({ children }: FormFieldGroupProps) => {
   return <div className="form-field-group group w-full flex flex-row">{children}</div>;
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-export { Alert } from "./alert";
+export { Alert, AlertIntent } from "./alert";
 export { InlineAlert } from "./inline-alert";
 export { Avatar } from "./avatar";
 export { Badge } from "./badge";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,7 +19,7 @@ export { Spinner } from "./spinner";
 export { SpinnerOverlay } from "./spinner-overlay";
 export { Tab } from "./tab";
 export { TableUnvirtualized } from "./table-unvirtualized";
-export { TableVirtualized } from "./table-virtualized";
+export { TableVirtualized, TableVirtualizedProps } from "./table-virtualized";
 export { Tag } from "./tag";
 export { Toast } from "./toast";
 export { Toggle } from "./toggle";

--- a/src/components/tab/tab-button.tsx
+++ b/src/components/tab/tab-button.tsx
@@ -3,7 +3,7 @@ import { Tab as HeadlessTab, TabProps } from '@headlessui/react';
 import { TabType, useTabContext } from './tab-context';
 import classNames from '../../util/class-names';
 
-interface TabButtonProps<TTag extends React.ElementType> extends TabProps<React.ElementType> {
+export interface TabButtonProps<TTag extends React.ElementType> extends TabProps<React.ElementType> {
   children: React.ReactNode;
   as?: TTag;
 }

--- a/src/components/tab/tab-panel.tsx
+++ b/src/components/tab/tab-panel.tsx
@@ -1,7 +1,7 @@
 import { Tab as HeadlessTab } from '@headlessui/react';
 import React from 'react';
 
-interface TabPanelProps {
+export interface TabPanelProps {
   children: React.ReactNode;
 }
 

--- a/src/components/table-virtualized/index.ts
+++ b/src/components/table-virtualized/index.ts
@@ -1,1 +1,1 @@
-export { TableVirtualized } from "./table-virtualized";
+export { TableVirtualized, TableVirtualizedProps } from "./table-virtualized";

--- a/src/components/table-virtualized/table-virtualized.tsx
+++ b/src/components/table-virtualized/table-virtualized.tsx
@@ -35,15 +35,15 @@ export interface TableVirtualizedProps<TableData> {
 }
 
 export const TableVirtualized = <TableData, >({
-                                                isDraggableRowsEnabled = false,
-                                                isExpandableRowsEnabled = false,
-                                                getExpandableContent,
-                                                data,
-                                                showPlaceholder = false,
-                                                placeholder,
-                                                columnDefs,
-                                                virtualizerOptions = {},
-                                              }: TableVirtualizedProps<TableData>) => {
+  isDraggableRowsEnabled = false,
+  isExpandableRowsEnabled = false,
+  getExpandableContent,
+  data,
+  showPlaceholder = false,
+  placeholder,
+  columnDefs,
+  virtualizerOptions = {},
+}: TableVirtualizedProps<TableData>) => {
   const virtualContainerRef = React.useRef<HTMLDivElement>(null);
   const [tableData, setTableData] = React.useState([...data]);
   const [sorting, setSorting] = React.useState<SortingState>([]);


### PR DESCRIPTION
This MR fixes some more import/types issues that occurs when running `npm run build`. 
Also added exports to `AlertIntent` and `TableVirtualizedProp` interfaces.