### PR TITLE
fix(multi-combobox-options): Add z-index to multicombobox options

### DIFF
--- a/src/components/form-field/multi-combobox/multi-combobox-options.tsx
+++ b/src/components/form-field/multi-combobox/multi-combobox-options.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import { Combobox as HeadlessCombobox } from "@headlessui/react";
+import { classNames } from "../../../util/class-names";
 
 export interface MultiComboboxOptionsProps {
     children: React.ReactNode;
+    className?: string;
 }
 
-const MultiComboboxOptions = ({ children }: MultiComboboxOptionsProps) => {
+const MultiComboboxOptions = ({ children, className }: MultiComboboxOptionsProps) => {
     return (
         <HeadlessCombobox.Options
             hold
-            className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md border border-neutral-300 bg-neutral-0 shadow-md outline-none ring-0"
+            className={classNames(
+                "absolute mt-1 max-h-60 w-full overflow-auto rounded-md border border-neutral-300 bg-neutral-0 shadow-md outline-none ring-0",
+                className
+            )}
         >
             {children}
         </HeadlessCombobox.Options>


### PR DESCRIPTION
## Description

Added z-index to multi-combobox options to fix the issue shown in the image:

<img width="665" alt="image" src="https://github.com/abusix/hailstorm/assets/6244177/7a324f63-c3aa-4020-8c60-3a74b29e8f04">

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime