### PR TITLE
fix(components): prevent alert icon to shrink

### DIFF
--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -42,8 +42,8 @@ export const Alert = ({ title, children, intent }: AlertProps) => {
                 alertVariants[intent]
             )}
         >
-            <Icon className={classNames("h-4 w-4", iconVariants[intent])} />
-            <div>
+            <Icon className={classNames("h-4 w-4 flex-shrink-0", iconVariants[intent])} />
+            <div className="flex-grow">
                 <div className="text-sm font-medium">{title}</div>
                 {children && <div className="pt-1 text-sm text-neutral-800">{children}</div>}
             </div>


### PR DESCRIPTION
## Description

This PR fixes an issue with the intent icon that shrinks unintended when text is too long in the alert description. 

## Checklist

- [x] Change increases quality
- [x] Change is validated by tests
- [x] Change is readable and easy to understand
- [x] Documentation is updated
- [x] Security impact has been considered
- [x] Changes validated in runtime