### PR TITLE
feat(components): add support for anchor tag buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "eslint-plugin-tsdoc": "0.2.17",
                 "jsdom": "^22.1.0",
                 "prettier": "^3.0.3",
-                "prettier-plugin-tailwindcss": "0.5.5",
+                "prettier-plugin-tailwindcss": "0.5.7",
                 "prop-types": "^15.8.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -21636,9 +21636,9 @@
             }
         },
         "node_modules/prettier-plugin-tailwindcss": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.5.tgz",
-            "integrity": "sha512-voy0CjWv/CM8yeaduv5ZwovovpTGMR5LbzlhGF+LtEvMJt9wBeVTVnW781hL38R/RcDXCJwN2rolsgr94B/n0Q==",
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.7.tgz",
+            "integrity": "sha512-4v6uESAgwCni6YF6DwJlRaDjg9Z+al5zM4JfngcazMy4WEf/XkPS5TEQjbD+DZ5iNuG6RrKQLa/HuX2SYzC3kQ==",
             "dev": true,
             "engines": {
                 "node": ">=14.21.3"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "eslint-plugin-tsdoc": "0.2.17",
         "jsdom": "^22.1.0",
         "prettier": "^3.0.3",
-        "prettier-plugin-tailwindcss": "0.5.5",
+        "prettier-plugin-tailwindcss": "0.5.7",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -44,6 +44,12 @@ export const WithIcons: Story = {
         RightIcon: icons.LockIcon,
     },
 };
+export const AsAnchor: Story = {
+    args: {
+        as: "a",
+        href: "https://www.google.com",
+    },
+};
 export const Loading: Story = {
     args: { loading: true },
 };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -28,6 +28,7 @@ const iconVariants = {
 type ButtonOrLinkProps =
     | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
           as?: "button";
+          href?: undefined;
       })
     | (React.AnchorHTMLAttributes<HTMLAnchorElement> & {
           as: "a";
@@ -49,37 +50,23 @@ const Button = ({
     RightIcon,
     ...props
 }: ButtonProps) => {
+    const HtmlTag = (props.as || "button") as React.ElementType;
+
     const commonClasses = classNames(
         `group flex h-8 items-center gap-2 whitespace-nowrap rounded px-4 text-xs font-semibold focus:outline-none disabled:cursor-not-allowed`,
         buttonVariants[variant],
         className
     );
 
-    const content = () => {
-        return (
-            <>
-                {loading ? <Spinner size="small" /> : null}
-                {LeftIcon && !loading ? (
-                    <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} />
-                ) : null}
-                {children}
-                {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
-            </>
-        );
-    };
-
-    if (props.as === "a") {
-        return (
-            <a className={commonClasses} {...props}>
-                {content()}
-            </a>
-        );
-    }
-
     return (
-        <button className={commonClasses} {...props}>
-            {content()}
-        </button>
+        <HtmlTag className={commonClasses} {...props}>
+            {loading ? <Spinner size="small" /> : null}
+            {LeftIcon && !loading ? (
+                <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} />
+            ) : null}
+            {children}
+            {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+        </HtmlTag>
     );
 };
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -25,12 +25,20 @@ const iconVariants = {
     "danger-secondary": "",
 };
 
-export interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+type ButtonOrLinkProps =
+    | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
+          as?: "button";
+      })
+    | (React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+          as: "a";
+      });
+
+export type ButtonProps = {
     variant?: keyof typeof buttonVariants;
     loading?: boolean;
     LeftIcon?: React.ElementType;
     RightIcon?: React.ElementType;
-}
+} & ButtonOrLinkProps;
 
 const Button = ({
     variant = "primary",
@@ -41,24 +49,36 @@ const Button = ({
     RightIcon,
     ...props
 }: ButtonProps) => {
+    const commonClasses = classNames(
+        `group flex h-8 items-center gap-2 whitespace-nowrap rounded px-4 text-xs font-semibold focus:outline-none disabled:cursor-not-allowed`,
+        buttonVariants[variant],
+        className
+    );
+
+    const content = () => {
+        return (
+            <>
+                {loading ? <Spinner size="small" /> : null}
+                {LeftIcon && !loading ? (
+                    <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} />
+                ) : null}
+                {children}
+                {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+            </>
+        );
+    };
+
+    if (props.as === "a") {
+        return (
+            <a className={commonClasses} {...props}>
+                {content()}
+            </a>
+        );
+    }
+
     return (
-        <button
-            className={classNames(
-                `group flex h-8 items-center gap-2 whitespace-nowrap rounded px-4 text-xs font-semibold focus:outline-none disabled:cursor-not-allowed`,
-                buttonVariants[variant],
-                className
-            )}
-            {...props}
-        >
-            {loading ? <Spinner size="small" /> : null}
-
-            {LeftIcon && !loading ? (
-                <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} />
-            ) : null}
-
-            {children}
-
-            {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+        <button className={commonClasses} {...props}>
+            {content()}
         </button>
     );
 };


### PR DESCRIPTION
## Description

We are adding the "as"-prop to the button to support anchor tags styled as a normal button.

Note: need to bump up the version of tailwind prettier plugin since prettier has some breaking changes.