### PR TITLE
fix(components): use correct background on read only inputs

### DIFF
--- a/src/components/form-field/text-input/text-input.stories.tsx
+++ b/src/components/form-field/text-input/text-input.stories.tsx
@@ -68,7 +68,7 @@ export const WithError: Story = {
 export const WithLeftIcon: Story = {
     render: () => (
         <div className="w-72">
-            <TextInputWithHooks hasLeftIcon error />
+            <TextInputWithHooks hasLeftIcon />
         </div>
     ),
 };

--- a/src/components/form-field/text-input/text-input.tsx
+++ b/src/components/form-field/text-input/text-input.tsx
@@ -64,7 +64,7 @@ export const TextInput = ({
                     targetAttachmentIdentifier,
                     "paragraph-100 relative block h-8 w-full rounded border border-neutral-400 py-2 pl-3 pr-2 text-neutral-800 placeholder:text-neutral-600 focus:outline-none",
                     LeftIcon && "pl-9",
-                    readOnly && "bg-neutral-100",
+                    readOnly && "bg-primary-50",
                     disabled && "cursor-not-allowed bg-neutral-100 text-neutral-600",
                     !error &&
                         !disabled &&


### PR DESCRIPTION
## Description

We change the background of read only text inputs to a soft primary color.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime