### PR TITLE
feat(components): pass close function to disclosure root component

### DIFF
--- a/src/components/navigation/navigation-disclosure.tsx
+++ b/src/components/navigation/navigation-disclosure.tsx
@@ -16,26 +16,28 @@ const NavigationDisclosureButton = ({ children, LeftIcon }: NavigationDisclosure
     );
 };
 
-type CloseFunction = (
-    focusableElement?: HTMLElement | React.MutableRefObject<HTMLElement | null>
-) => void;
+interface CloseFunction {
+    (focusableElement?: HTMLElement | React.MutableRefObject<HTMLElement | null>): void;
+}
 
-type ChildrenType = (({ close }: { close: CloseFunction }) => React.ReactNode) | React.ReactNode;
+interface ChildrenType {
+    (props: { close: CloseFunction }): React.ReactNode;
+}
+
+export interface NavigationDisclosureProps {
+    children: ChildrenType | React.ReactNode;
+    defaultOpen?: boolean;
+}
 
 const renderDisclosureChildren = ({
     children,
     close,
 }: {
-    children: ChildrenType;
+    children: ChildrenType | React.ReactNode;
     close: CloseFunction;
 }) => {
     return typeof children === "function" ? children({ close }) : children;
 };
-
-export interface NavigationDisclosureProps {
-    children: ChildrenType;
-    defaultOpen?: boolean;
-}
 
 const NavigationDisclosure = ({ children, defaultOpen }: NavigationDisclosureProps) => {
     return (

--- a/src/components/navigation/navigation-disclosure.tsx
+++ b/src/components/navigation/navigation-disclosure.tsx
@@ -16,15 +16,31 @@ const NavigationDisclosureButton = ({ children, LeftIcon }: NavigationDisclosure
     );
 };
 
+type CloseFunction = (
+    focusableElement?: HTMLElement | React.MutableRefObject<HTMLElement | null>
+) => void;
+
+type ChildrenType = (({ close }: { close: CloseFunction }) => React.ReactNode) | React.ReactNode;
+
+const renderDisclosureChildren = ({
+    children,
+    close,
+}: {
+    children: ChildrenType;
+    close: CloseFunction;
+}) => {
+    return typeof children === "function" ? children({ close }) : children;
+};
+
 export interface NavigationDisclosureProps {
-    children: React.ReactNode;
+    children: ChildrenType;
     defaultOpen?: boolean;
 }
 
 const NavigationDisclosure = ({ children, defaultOpen }: NavigationDisclosureProps) => {
     return (
         <Disclosure as="div" defaultOpen={defaultOpen}>
-            {children}
+            {({ close }) => <>{renderDisclosureChildren({ children, close })}</>}
         </Disclosure>
     );
 };


### PR DESCRIPTION
## Description

Pass the HeadlessUI close function to children as function children.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime