### PR TITLE
feat(components): use button for disclosure nav item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
                 "vitest": "^1.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "react": ">=17.0.1",

--- a/src/components/navigation/navigation-disclosure-panel.tsx
+++ b/src/components/navigation/navigation-disclosure-panel.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Disclosure } from "@headlessui/react";
 import { classNames } from "../../util/class-names";
 
-export interface NavigationDisclosurePanelItemProps {
-    children: React.ReactNode;
+export interface NavigationDisclosurePanelItemProps
+    extends React.ComponentPropsWithoutRef<"button"> {
     isActive?: boolean;
     isIndented?: boolean;
 }
@@ -12,20 +12,23 @@ const NavigationDisclosurePanelItem = ({
     children,
     isActive,
     isIndented,
+    ...props
 }: NavigationDisclosurePanelItemProps) => {
     return (
-        <div
+        <button
+            type="button"
             className={classNames(
                 "relative w-full px-8 py-3 text-left text-sm text-neutral-0 hover:bg-primary-900+10",
                 isIndented && "px-14",
                 isActive && "bg-primary-900+20 font-semibold hover:bg-primary-900+20"
             )}
+            {...props}
         >
             {children}
             {isActive && (
                 <div className="absolute bottom-0 left-0 top-0 h-full w-0.5 rounded-r-sm bg-neutral-0" />
             )}
-        </div>
+        </button>
     );
 };
 


### PR DESCRIPTION
## Description

For a11y reasons we change the navigation item to a button instead of a div. This also supports click events for manually closing the disclosure root element in combination with the render function `close`

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime