### PR TITLE
fix(NavigationPopover): use react-popper for handling in a better way the positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
             "dependencies": {
                 "@headlessui/react": "^1.7.17",
                 "@headlessui/tailwindcss": "^0.2.0",
+                "@popperjs/core": "^2.11.8",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tanstack/react-table": "^8.10.7",
                 "@tanstack/react-virtual": "^3.0.1",
                 "@tanstack/table-core": "^8.10.7",
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1",
+                "react-popper": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "devDependencies": {
@@ -3711,6 +3713,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -16400,8 +16411,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
             "version": "3.14.1",
@@ -17020,7 +17030,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -23767,11 +23776,30 @@
             "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
             "dev": true
         },
+        "node_modules/react-fast-compare": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+        },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
+        },
+        "node_modules/react-popper": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+            "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+            "dependencies": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            },
+            "peerDependencies": {
+                "@popperjs/core": "^2.0.0",
+                "react": "^16.8.0 || ^17 || ^18",
+                "react-dom": "^16.8.0 || ^17 || ^18"
+            }
         },
         "node_modules/react-refresh": {
             "version": "0.14.0",
@@ -28092,6 +28120,14 @@
             "dev": true,
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "dependencies": {
         "@headlessui/react": "^1.7.17",
         "@headlessui/tailwindcss": "^0.2.0",
+        "@popperjs/core": "^2.11.8",
         "@tailwindcss/forms": "^0.5.7",
         "@tanstack/react-table": "^8.10.7",
         "@tanstack/react-virtual": "^3.0.1",
         "@tanstack/table-core": "^8.10.7",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
+        "react-popper": "^2.3.0",
         "tslib": "^2.6.2"
     },
     "devDependencies": {

--- a/src/components/navigation/navigation-popover-button.tsx
+++ b/src/components/navigation/navigation-popover-button.tsx
@@ -1,0 +1,26 @@
+import { Popover } from "@headlessui/react";
+import React from "react";
+import { useNavigationPopoverContext } from "./navigation-popover-context";
+
+export interface NavigationPopoverButtonProps {
+    LeftIcon?: React.ElementType;
+    children: React.ReactNode;
+}
+
+export const NavigationPopoverButton = ({ children, LeftIcon }: NavigationPopoverButtonProps) => {
+    const {
+        popoverButton: { setReferenceElement },
+    } = useNavigationPopoverContext();
+
+    return (
+        <Popover.Button
+            ref={(el) => el && setReferenceElement(el)}
+            className="flex w-full items-center gap-x-3 px-4 py-3 text-left text-sm text-neutral-0 hover:bg-primary-900+10 ui-open:bg-primary-900+8 ui-open:font-semibold"
+        >
+            <>
+                {LeftIcon && <LeftIcon className="h-4 w-4" />}
+                {children}
+            </>
+        </Popover.Button>
+    );
+};

--- a/src/components/navigation/navigation-popover-context.tsx
+++ b/src/components/navigation/navigation-popover-context.tsx
@@ -1,0 +1,25 @@
+import { CSSProperties, createContext, useContext } from "react";
+
+export const NavigationPopoverContext = createContext<{
+    popoverButton: {
+        setReferenceElement: React.Dispatch<React.SetStateAction<HTMLButtonElement | undefined>>;
+    };
+    popoverPanel: {
+        setPopperElement: React.Dispatch<React.SetStateAction<HTMLDivElement | undefined>>;
+        styles: CSSProperties;
+        attributes: { [key: string]: string } | undefined;
+    };
+}>({
+    popoverButton: {
+        setReferenceElement: () => {},
+    },
+    popoverPanel: {
+        setPopperElement: () => {},
+        styles: {},
+        attributes: {},
+    },
+});
+
+export const useNavigationPopoverContext = () => useContext(NavigationPopoverContext);
+
+export const NavigationPopoverContextProvider = NavigationPopoverContext.Provider;

--- a/src/components/navigation/navigation-popover-panel.tsx
+++ b/src/components/navigation/navigation-popover-panel.tsx
@@ -1,0 +1,40 @@
+import { Popover } from "@headlessui/react";
+import React from "react";
+import { useNavigationPopoverContext } from "./navigation-popover-context";
+
+export interface NavigationPopoverPanelItemProps {
+    children: React.ReactNode;
+}
+
+const NavigationPopoverPanelItem = ({ children }: NavigationPopoverPanelItemProps) => {
+    return (
+        <div className="flex w-full cursor-pointer items-center overflow-hidden p-2">
+            <p className="text-sm font-normal">{children}</p>
+        </div>
+    );
+};
+
+export interface NavigationPopoverPanelProps {
+    children: React.ReactNode;
+}
+
+const NavigationPopoverPanel = ({ children }: NavigationPopoverPanelProps) => {
+    const {
+        popoverPanel: { setPopperElement, styles, attributes },
+    } = useNavigationPopoverContext();
+
+    return (
+        <Popover.Panel
+            ref={(el) => el && setPopperElement(el)}
+            style={styles}
+            {...attributes}
+            className="z-40 ml-2 w-52 rounded bg-neutral-0 p-2 shadow"
+        >
+            {children}
+        </Popover.Panel>
+    );
+};
+
+NavigationPopoverPanel.Item = NavigationPopoverPanelItem;
+
+export { NavigationPopoverPanel };

--- a/src/components/navigation/navigation-popover.tsx
+++ b/src/components/navigation/navigation-popover.tsx
@@ -1,47 +1,9 @@
 import { Popover } from "@headlessui/react";
-import React from "react";
-
-export interface NavigationPopoverButtonProps {
-    LeftIcon?: React.ElementType;
-    children: React.ReactNode;
-}
-
-const NavigationPopoverButton = ({ children, LeftIcon }: NavigationPopoverButtonProps) => {
-    return (
-        <Popover.Button className="flex w-full items-center gap-x-3 px-4 py-3 text-left text-sm text-neutral-0 hover:bg-primary-900+10 ui-open:bg-primary-900+8 ui-open:font-semibold">
-            <>
-                {LeftIcon && <LeftIcon className="h-4 w-4" />}
-                {children}
-            </>
-        </Popover.Button>
-    );
-};
-
-export interface NavigationPopoverPanelItemProps {
-    children: React.ReactNode;
-}
-
-const NavigationPopoverPanelItem = ({ children }: NavigationPopoverPanelItemProps) => {
-    return (
-        <div className="flex w-full cursor-pointer items-center overflow-hidden p-2">
-            <p className="text-sm font-normal">{children}</p>
-        </div>
-    );
-};
-
-export interface NavigationPopoverPanelProps {
-    children: React.ReactNode;
-}
-
-const NavigationPopoverPanel = ({ children }: NavigationPopoverPanelProps) => {
-    return (
-        <Popover.Panel className="absolute bottom-0 z-40 ml-2 w-52 translate-x-[180px] rounded bg-neutral-0 p-2">
-            {children}
-        </Popover.Panel>
-    );
-};
-
-NavigationPopoverPanel.Item = NavigationPopoverPanelItem;
+import React, { useState } from "react";
+import { usePopper } from "react-popper";
+import { NavigationPopoverButton } from "./navigation-popover-button";
+import { NavigationPopoverContextProvider } from "./navigation-popover-context";
+import { NavigationPopoverPanel } from "./navigation-popover-panel";
 
 export interface NavigationPopoverProps {
     children: React.ReactNode;
@@ -49,15 +11,32 @@ export interface NavigationPopoverProps {
 }
 
 const NavigationPopover = ({ children, showOverlay }: NavigationPopoverProps) => {
+    const [referenceElement, setReferenceElement] = useState<HTMLButtonElement>();
+    const [popperElement, setPopperElement] = useState<HTMLDivElement>();
+    const { styles, attributes } = usePopper(referenceElement, popperElement, {
+        placement: "right-end",
+    });
+
+    const context = {
+        popoverButton: {
+            setReferenceElement,
+        },
+        popoverPanel: {
+            setPopperElement,
+            styles: styles.popper,
+            attributes: attributes.popper,
+        },
+    };
+
     return (
-        <Popover>
-            <>
+        <NavigationPopoverContextProvider value={context}>
+            <Popover>
                 {showOverlay && (
                     <Popover.Overlay className="fixed inset-0 z-30 translate-x-[180px] bg-modal-background" />
                 )}
-                <div className="relative">{children}</div>
-            </>
-        </Popover>
+                {children}
+            </Popover>
+        </NavigationPopoverContextProvider>
     );
 };
 

--- a/src/components/navigation/navigation.stories.tsx
+++ b/src/components/navigation/navigation.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
-import { Navigation } from "./navigation";
 import { CogIcon, HelpIcon, InfoSignIcon } from "../../icons";
+import { Navigation } from "./navigation";
 
 const meta: Meta<typeof Navigation> = {
     title: "Navigation",

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -16,7 +16,11 @@ export interface NavigationProps {
 }
 
 const Navigation = ({ children }: NavigationProps) => {
-    return <div className="flex w-[180px] grow flex-col bg-primary-900 pb-5 pt-3">{children}</div>;
+    return (
+        <div className="flex w-[180px] grow flex-col overflow-y-auto bg-primary-900 pb-5 pt-3">
+            {children}
+        </div>
+    );
 };
 
 Navigation.Logo = NavigationLogo;


### PR DESCRIPTION
## Description

This PR implements the lib `react-popper` to handle in a better way the positioning of the popover as suggested on the [headless-ui documentation](https://headlessui.com/react/popover#positioning-the-panel).

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime