### PR TITLE
fix(NavigationPopoverOverlay): Add portal to overlay to send it to th…

### DIFF
--- a/src/components/navigation/navigation-popover-overlay.tsx
+++ b/src/components/navigation/navigation-popover-overlay.tsx
@@ -1,0 +1,6 @@
+import { Popover } from "@headlessui/react";
+import * as React from "react";
+
+export const NavigationPopoverOverlay = () => (
+    <Popover.Overlay className="fixed inset-0 z-30 translate-x-[180px] bg-modal-background" />
+);

--- a/src/components/navigation/navigation-popover.tsx
+++ b/src/components/navigation/navigation-popover.tsx
@@ -3,18 +3,18 @@ import React, { useState } from "react";
 import { usePopper } from "react-popper";
 import { NavigationPopoverButton } from "./navigation-popover-button";
 import { NavigationPopoverContextProvider } from "./navigation-popover-context";
+import { NavigationPopoverOverlay } from "./navigation-popover-overlay";
 import { NavigationPopoverPanel } from "./navigation-popover-panel";
 
 export interface NavigationPopoverProps {
     children: React.ReactNode;
-    showOverlay?: boolean;
 }
 
-const NavigationPopover = ({ children, showOverlay }: NavigationPopoverProps) => {
+const NavigationPopover = ({ children }: NavigationPopoverProps) => {
     const [referenceElement, setReferenceElement] = useState<HTMLButtonElement>();
     const [popperElement, setPopperElement] = useState<HTMLDivElement>();
     const { styles, attributes } = usePopper(referenceElement, popperElement, {
-        placement: "right-end",
+        placement: "top-start",
     });
 
     const context = {
@@ -30,17 +30,13 @@ const NavigationPopover = ({ children, showOverlay }: NavigationPopoverProps) =>
 
     return (
         <NavigationPopoverContextProvider value={context}>
-            <Popover>
-                {showOverlay && (
-                    <Popover.Overlay className="fixed inset-0 z-30 translate-x-[180px] bg-modal-background" />
-                )}
-                {children}
-            </Popover>
+            <Popover>{children}</Popover>
         </NavigationPopoverContextProvider>
     );
 };
 
 NavigationPopover.Button = NavigationPopoverButton;
 NavigationPopover.Panel = NavigationPopoverPanel;
+NavigationPopover.Overlay = NavigationPopoverOverlay;
 
 export { NavigationPopover };

--- a/src/components/navigation/navigation.stories.tsx
+++ b/src/components/navigation/navigation.stories.tsx
@@ -64,6 +64,7 @@ export const Default: Story = {
                             <Navigation.Popover.Button LeftIcon={HelpIcon}>
                                 Support
                             </Navigation.Popover.Button>
+                            <Navigation.Popover.Overlay />
                             <Navigation.Popover.Panel>
                                 <Navigation.Popover.Panel.Item>
                                     Documentation


### PR DESCRIPTION
## Description

- Offer more flexibility by exporting navigation overlay, allowing the client to deal with overlapping issues.
- Change popover placement to be `top-start`

This fixes the overlapping issue by allowing the client to add a portal and send it to the beginning of the document (I already tested it using the `next` channel):
![image](https://github.com/abusix/hailstorm/assets/6244177/c3805bf9-c8b4-4f13-859c-de4dc52aa501)

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime