### PR TITLE
fix(dependencies): overwrite adobe/css-tools for jest-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "@storybook/react-vite": "^7.6.3",
                 "@storybook/testing-library": "^0.2.2",
                 "@svgr/cli": "8.1.0",
-                "@testing-library/jest-dom": "^6.1.5",
+                "@testing-library/jest-dom": "6.1.5",
                 "@testing-library/react": "^14.1.2",
                 "@types/react": "^18.2.42",
                 "@typescript-eslint/eslint-plugin": "6.13.2",
@@ -98,9 +98,9 @@
             }
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-            "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+            "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
             "dev": true
         },
         "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@storybook/react-vite": "^7.6.3",
         "@storybook/testing-library": "^0.2.2",
         "@svgr/cli": "8.1.0",
-        "@testing-library/jest-dom": "^6.1.5",
+        "@testing-library/jest-dom": "6.1.5",
         "@testing-library/react": "^14.1.2",
         "@types/react": "^18.2.42",
         "@typescript-eslint/eslint-plugin": "6.13.2",
@@ -118,6 +118,9 @@
     "overrides": {
         "optionator": {
             "word-wrap@1.2.3": "1.2.5"
+        },
+        "@testing-library/jest-dom@6.1.5": {
+            "@adobe/css-tools": "4.3.2"
         }
     }
 }


### PR DESCRIPTION
## Description

Overwrite adobe/css-tools used by jest-dom.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime