### PR TITLE
fix(components): pass className prop to tab panels wrapper

### DIFF
--- a/src/components/tab/tab-panels.tsx
+++ b/src/components/tab/tab-panels.tsx
@@ -3,8 +3,9 @@ import { Tab as HeadlessTab } from "@headlessui/react";
 
 export interface TabPanelsProps {
     children: React.ReactNode;
+    className?: string;
 }
 
-export const TabPanels = ({ children }: TabPanelsProps) => {
-    return <HeadlessTab.Panels>{children}</HeadlessTab.Panels>;
+export const TabPanels = ({ children, className }: TabPanelsProps) => {
+    return <HeadlessTab.Panels className={className}>{children}</HeadlessTab.Panels>;
 };


### PR DESCRIPTION
## Description

Add className prop to tab panels wrapper.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime