### PR TITLE
fix: removed gap-2 in radio boxes option

### DIFF
--- a/src/components/form-field/radio-box/radio-box-option.tsx
+++ b/src/components/form-field/radio-box/radio-box-option.tsx
@@ -68,7 +68,7 @@ export const RadioBoxOption = ({ children, value, disabled, className }: RadioBo
                         )}
                     </div>
 
-                    <div className={classNames("flex flex-col gap-2", className)}>{children}</div>
+                    <div className={classNames("flex flex-col", className)}>{children}</div>
                 </div>
             )}
         </RadioGroup.Option>


### PR DESCRIPTION
This mr removes an unwanted gap between labels and descriptions of radio box option content/children