### PR TITLE
fix(TabPanel): Remove as={React.Fragment} prop

### DIFF
--- a/src/components/tab/tab-panel.tsx
+++ b/src/components/tab/tab-panel.tsx
@@ -6,5 +6,5 @@ export interface TabPanelProps {
 }
 
 export const TabPanel = ({ children }: TabPanelProps) => {
-    return <HeadlessTab.Panel as={React.Fragment}>{children}</HeadlessTab.Panel>;
+    return <HeadlessTab.Panel>{children}</HeadlessTab.Panel>;
 };


### PR DESCRIPTION
## Description

Remove the `as={React.Fragment}` prop, as this will throw a console error when headless ui attempts to pass down some basic HTML attributes.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime