### PR TITLE
fix(components): use fragment for tooltip return value

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -66,7 +66,7 @@ export const Tooltip = ({
     );
 
     return (
-        <div>
+        <>
             <div
                 ref={(el) => el && setReferenceElement(el)}
                 onMouseEnter={() => !isControlled && setShow(true)}
@@ -79,6 +79,6 @@ export const Tooltip = ({
             ) : (
                 renderTooltipContent()
             )}
-        </div>
+        </>
     );
 };


### PR DESCRIPTION
## Description

- return fragment for tooltip instead of div

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime