### PR TITLE
BREAKING CHANGE: split button/link component and support asChild for links

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,6 +40,7 @@ module.exports = {
             },
         ],
         "react/jsx-props-no-spreading": "off",
+        "react/prop-types": "off",
     },
     overrides: [
         {

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -44,12 +44,6 @@ export const WithIcons: Story = {
         RightIcon: icons.LockIcon,
     },
 };
-export const AsAnchor: Story = {
-    args: {
-        as: "a",
-        href: "https://www.google.com",
-    },
-};
 export const Loading: Story = {
     args: { loading: true },
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,3 +31,4 @@ export { TopBar } from "./top-bar";
 export { Disclosure } from "./disclosure";
 export { ButtonGroup } from "./button-group";
 export { FeaturedTag } from "./featured-tag";
+export { Link } from "./link";

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -1,0 +1,1 @@
+export { Link } from "./link";

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Link } from "./link";
+import { ChatIcon, DiagramTreeIcon, LockIcon } from "../../icons";
+import { hiddenArgControl } from "../../util/storybook-utils";
+
+const icons = { undefined, ChatIcon, DiagramTreeIcon, LockIcon };
+const iconArg = {
+    description: "Icon component",
+    options: Object.keys(icons),
+    mapping: icons,
+};
+
+const meta: Meta<typeof Link> = {
+    title: "Link",
+    component: Link,
+    args: {
+        children: "Link Label",
+        LeftIcon: undefined,
+        RightIcon: undefined,
+    },
+    argTypes: {
+        LeftIcon: iconArg,
+        RightIcon: iconArg,
+        asChild: hiddenArgControl,
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {
+    render: (args) => (
+        <Link href="https://www.google.de/" {...args} asChild={false}>
+            {args.children}
+        </Link>
+    ),
+};
+
+export const AsChild: Story = {
+    render: (args) => (
+        <Link {...args} asChild>
+            <a href="https://www.google.de/">{args.children}</a>
+        </Link>
+    ),
+};
+
+export const WithChilds: Story = {
+    argTypes: {
+        children: hiddenArgControl,
+    },
+    render: (args) => (
+        <Link href="https://www.google.de/" {...args} asChild={false}>
+            <div>
+                <span>Nested</span>
+                <span>Elements</span>
+            </div>
+        </Link>
+    ),
+};

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable react/button-has-type */
 import React from "react";
+import { AsChildProps, Slot } from "../slot/slot";
 import { classNames } from "../../util/class-names";
-import { Spinner } from "../spinner";
 
-const buttonVariants = {
+const linkVariants = {
     primary:
         "bg-primary-500 text-neutral-0 hover:bg-primary-600 active:bg-primary-600 focus:ring-2 focus:ring-primary-200 focus:bg-primary-600 disabled:bg-primary-200 fill-neutral-0",
     secondary:
@@ -25,38 +24,52 @@ const iconVariants = {
     "danger-secondary": "",
 };
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: keyof typeof buttonVariants;
-    loading?: boolean;
+type LinkProps = AsChildProps<React.AnchorHTMLAttributes<HTMLAnchorElement>> & {
+    className?: string;
+    variant?: keyof typeof linkVariants;
     LeftIcon?: React.ElementType;
     RightIcon?: React.ElementType;
-}
+};
 
-const Button = ({
+export const Link = ({
     variant = "primary",
     className,
     children,
-    loading,
     LeftIcon,
     RightIcon,
+    asChild = false,
     ...props
-}: ButtonProps) => {
+}: LinkProps) => {
+    const Comp = asChild ? Slot : "a";
     const commonClasses = classNames(
-        `group flex h-8 items-center gap-2 whitespace-nowrap rounded px-4 text-xs font-semibold focus:outline-none disabled:cursor-not-allowed`,
-        buttonVariants[variant],
+        `group flex h-8 items-center gap-2 whitespace-nowrap rounded px-4 text-xs font-semibold focus:outline-none disabled:cursor-not-allowed `,
+        linkVariants[variant],
         className
     );
 
+    if (React.isValidElement(children)) {
+        return React.cloneElement(children, {
+            ...children.props,
+            children: (
+                <>
+                    {LeftIcon ? <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+                    {children.props.children}
+                    {RightIcon ? (
+                        <RightIcon className={`${iconVariants[variant]} h-3 w-3`} />
+                    ) : null}
+                </>
+            ),
+            className: commonClasses,
+        });
+    }
+
     return (
-        <button className={commonClasses} {...props}>
-            {loading ? <Spinner size="small" /> : null}
-            {LeftIcon && !loading ? (
-                <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} />
-            ) : null}
-            {children}
-            {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
-        </button>
+        <Comp {...props} className={commonClasses}>
+            <>
+                {LeftIcon ? <LeftIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+                {children}
+                {RightIcon ? <RightIcon className={`${iconVariants[variant]} h-3 w-3`} /> : null}
+            </>
+        </Comp>
     );
 };
-
-export { Button };

--- a/src/components/slot/slot.tsx
+++ b/src/components/slot/slot.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { classNames } from "../../util/class-names";
+
+export type AsChildProps<DefaultElementProps> =
+    | ({ asChild?: false } & DefaultElementProps)
+    | { asChild: true; children: React.ReactNode };
+
+export const Slot = ({
+    children,
+    ...props
+}: React.HTMLAttributes<HTMLElement> & {
+    children?: React.ReactNode;
+}) => {
+    if (React.isValidElement(children)) {
+        return React.cloneElement(children, {
+            ...props,
+            ...children.props,
+            style: {
+                ...props.style,
+                ...children.props.style,
+            },
+            className: classNames(props.className, props.className, children.props.className),
+        });
+    }
+
+    if (React.Children.count(children) > 1) {
+        React.Children.only(null);
+    }
+
+    return null;
+};


### PR DESCRIPTION
## Description

- split Button/Link component into two independent components
- support asChild prop for links (e.g. Next/Link can be used now)

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime