### PR TITLE
fix: remove unsupported ui-open class from Listbox button

### DIFF
--- a/src/components/form-field/listbox/listbox-button.tsx
+++ b/src/components/form-field/listbox/listbox-button.tsx
@@ -1,8 +1,8 @@
 import { Listbox } from "@headlessui/react";
 import React from "react";
+import { CaretDownIcon } from "../../../icons";
 import { ListboxButtonBadgeValue } from "./listbox-button-badge-value";
 import { ListboxButtonTextValue } from "./listbox-button-text-value";
-import { CaretDownIcon } from "../../../icons";
 
 export interface ListboxButtonProps {
     children: React.ReactNode;
@@ -10,7 +10,7 @@ export interface ListboxButtonProps {
 
 const ListboxButton = ({ children }: ListboxButtonProps) => {
     return (
-        <Listbox.Button className="group flex h-8 w-full cursor-pointer items-center rounded border border-neutral-400 bg-neutral-0 py-2 pl-3 pr-8 outline-none hover:border-neutral-600 focus:border-primary-400 focus:ring-2 focus:ring-primary-200 ui-open:border-primary-400 ui-open:ring-2 ui-open:ring-primary-200">
+        <Listbox.Button className="group flex h-8 w-full cursor-pointer items-center rounded border border-neutral-400 bg-neutral-0 py-2 pl-3 pr-8 outline-none hover:border-neutral-600 focus:border-primary-400 focus:ring-2 focus:ring-primary-200">
             {children}
             <div className="absolute inset-y-0 right-0 flex items-center px-1.5">
                 <div className="flex h-5 w-5 items-center justify-center rounded rounded-r-md bg-neutral-100  focus:outline-none">


### PR DESCRIPTION
## Description

We remove the ui-open state that gets applied when a listbox is inside a model/dialog. The ui-open state is always `true` when the outer dialog is in open state. This causes an always active ui-open state visually.
https://headlessui.com/v1/react/listbox#focus-management
The focus state is intended to get trapped and ui-open is not supported on the Listbox.Button component.