### PR TITLE
feat: added new popover-menu component

### DIFF
--- a/src/components/popover-menu/popover-menu-button.tsx
+++ b/src/components/popover-menu/popover-menu-button.tsx
@@ -1,0 +1,21 @@
+import { PopoverButton as HeadlessUiPopoverButton } from "@headlessui/react";
+import React from "react";
+import { usePopoverMenuContext } from "./popover-menu-context";
+import { Button, ButtonProps } from "../button/button";
+
+export interface NavigationPopoverButtonProps extends ButtonProps {
+    children: React.ReactNode;
+    onClick?: () => void;
+}
+
+export const PopoverMenuButton = ({ onClick, ...restProps }: NavigationPopoverButtonProps) => {
+    const {
+        popoverButton: { setReferenceElement },
+    } = usePopoverMenuContext();
+
+    return (
+        <HeadlessUiPopoverButton ref={(el) => el && setReferenceElement(el)} onClick={onClick}>
+            <Button {...restProps} />
+        </HeadlessUiPopoverButton>
+    );
+};

--- a/src/components/popover-menu/popover-menu-context.tsx
+++ b/src/components/popover-menu/popover-menu-context.tsx
@@ -1,0 +1,25 @@
+import { CSSProperties, createContext, useContext } from "react";
+
+export const PopoverMenuContext = createContext<{
+    popoverButton: {
+        setReferenceElement: React.Dispatch<React.SetStateAction<HTMLButtonElement | undefined>>;
+    };
+    popoverPanel: {
+        setPopperElement: React.Dispatch<React.SetStateAction<HTMLElement | undefined>>;
+        styles: CSSProperties;
+        attributes: { [key: string]: string } | undefined;
+    };
+}>({
+    popoverButton: {
+        setReferenceElement: () => {},
+    },
+    popoverPanel: {
+        setPopperElement: () => {},
+        styles: {},
+        attributes: {},
+    },
+});
+
+export const usePopoverMenuContext = () => useContext(PopoverMenuContext);
+
+export const PopoverMenuContextProvider = PopoverMenuContext.Provider;

--- a/src/components/popover-menu/popover-menu-overlay.tsx
+++ b/src/components/popover-menu/popover-menu-overlay.tsx
@@ -1,0 +1,6 @@
+import { PopoverBackdrop as HeadlessUiPopoverBackdrop } from "@headlessui/react";
+import * as React from "react";
+
+export const PopoverMenuOverlay = () => (
+    <HeadlessUiPopoverBackdrop className="fixed inset-0 z-30 bg-modal-background" />
+);

--- a/src/components/popover-menu/popover-menu-panel.tsx
+++ b/src/components/popover-menu/popover-menu-panel.tsx
@@ -1,0 +1,47 @@
+import { PopoverPanel as HeadlessUiPopoverPanel } from "@headlessui/react";
+import React from "react";
+import { usePopoverMenuContext } from "./popover-menu-context";
+
+export interface PopoverMenuPanelItemProps {
+    children: React.ReactNode;
+    onClick?: () => void;
+}
+
+const PopoverMenuPanelItem = ({ children, onClick }: PopoverMenuPanelItemProps) => {
+    return (
+        <div
+            className="flex w-full cursor-pointer items-center overflow-hidden px-4 py-2 hover:bg-neutral-100 focus:ring-2 focus:ring-primary-200"
+            onClick={onClick}
+            onKeyDown={onClick}
+            tabIndex={0}
+            role="button"
+        >
+            <p className="text-sm font-normal">{children}</p>
+        </div>
+    );
+};
+
+export interface NavigationPopoverPanelProps {
+    children: React.ReactNode;
+}
+
+const PopoverMenuPanel = ({ children }: NavigationPopoverPanelProps) => {
+    const {
+        popoverPanel: { setPopperElement, styles, attributes },
+    } = usePopoverMenuContext();
+
+    return (
+        <HeadlessUiPopoverPanel
+            ref={(el) => el && setPopperElement(el)}
+            style={styles}
+            {...attributes}
+            className="z-40 ml-2 w-52 rounded bg-neutral-0 py-2 shadow"
+        >
+            {children}
+        </HeadlessUiPopoverPanel>
+    );
+};
+
+PopoverMenuPanel.Item = PopoverMenuPanelItem;
+
+export { PopoverMenuPanel };

--- a/src/components/popover-menu/popover-menu.stories.tsx
+++ b/src/components/popover-menu/popover-menu.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { PopoverMenu } from "./popover-menu";
+
+const meta: Meta<typeof PopoverMenu> = {
+    title: "Popover Menu",
+    component: PopoverMenu,
+    parameters: {
+        options: {
+            showPanel: false,
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PopoverMenu>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="relative flex min-h-screen min-w-736 flex-col">
+            <PopoverMenu>
+                <PopoverMenu.Button variant="secondary">Open Popover Menu</PopoverMenu.Button>
+
+                <PopoverMenu.Overlay />
+
+                <PopoverMenu.Panel>
+                    <PopoverMenu.Panel.Item>Item 1</PopoverMenu.Panel.Item>
+                    <PopoverMenu.Panel.Item>Item 1</PopoverMenu.Panel.Item>
+                    <PopoverMenu.Panel.Item>Item 1</PopoverMenu.Panel.Item>
+                </PopoverMenu.Panel>
+            </PopoverMenu>
+        </div>
+    ),
+};

--- a/src/components/popover-menu/popover-menu.tsx
+++ b/src/components/popover-menu/popover-menu.tsx
@@ -1,0 +1,42 @@
+import { Popover } from "@headlessui/react";
+import React, { useState } from "react";
+import { usePopper } from "react-popper";
+import { PopoverMenuButton } from "./popover-menu-button";
+import { PopoverMenuContextProvider } from "./popover-menu-context";
+import { PopoverMenuOverlay } from "./popover-menu-overlay";
+import { PopoverMenuPanel } from "./popover-menu-panel";
+
+export interface PopoverMenuProps {
+    children: React.ReactNode;
+}
+
+const PopoverMenu = ({ children }: PopoverMenuProps) => {
+    const [referenceElement, setReferenceElement] = useState<HTMLButtonElement>();
+    const [popperElement, setPopperElement] = useState<HTMLElement>();
+    const { styles, attributes } = usePopper(referenceElement, popperElement, {
+        placement: "top-start",
+    });
+
+    const context = {
+        popoverButton: {
+            setReferenceElement,
+        },
+        popoverPanel: {
+            setPopperElement,
+            styles: styles.popper,
+            attributes: attributes.popper,
+        },
+    };
+
+    return (
+        <PopoverMenuContextProvider value={context}>
+            <Popover>{children}</Popover>
+        </PopoverMenuContextProvider>
+    );
+};
+
+PopoverMenu.Button = PopoverMenuButton;
+PopoverMenu.Panel = PopoverMenuPanel;
+PopoverMenu.Overlay = PopoverMenuOverlay;
+
+export { PopoverMenu };


### PR DESCRIPTION
I needed to add a new popover menu component (I’ve used the navigation popover implementation from our hailstorm as reference) to get rid of evergreen’s popover elements in portal :-)