### PR TITLE
fix: render passed children in tooltip parent

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -6,7 +6,7 @@ import { classNames } from "../../util/class-names";
 import { TooltipPortal } from "./tooltip-portal";
 
 interface TooltipProps {
-    children: React.ReactNode;
+    children: React.ReactElement;
     title: React.ReactNode;
     position?: Placement;
     className?: string;
@@ -32,6 +32,12 @@ export const Tooltip = ({
         placement: position,
         strategy: strategy === "fixed" ? "fixed" : "absolute",
         modifiers: [{ name: "offset", options: { offset: [0, 8] } }],
+    });
+
+    const childrenWithRef = React.cloneElement(children, {
+        ref: (el: HTMLDivElement) => setReferenceElement(el),
+        onMouseEnter: () => !isControlled && setShow(true),
+        onMouseLeave: () => !isControlled && setShow(false),
     });
 
     useEffect(() => {
@@ -67,13 +73,7 @@ export const Tooltip = ({
 
     return (
         <>
-            <div
-                ref={(el) => el && setReferenceElement(el)}
-                onMouseEnter={() => !isControlled && setShow(true)}
-                onMouseLeave={() => !isControlled && setShow(false)}
-            >
-                {children}
-            </div>
+            {childrenWithRef}
             {strategy === "portal" ? (
                 <TooltipPortal>{renderTooltipContent()}</TooltipPortal>
             ) : (


### PR DESCRIPTION
## Description

Instead of rendering a div around the child that causes layout issues, we now rendering the passed children with the ref for popper.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime