### PR TITLE
fix: pass missing props to table row

### DIFF
--- a/src/components/table-unvirtualized/table-body/table-body-row/table-body-row.tsx
+++ b/src/components/table-unvirtualized/table-body/table-body-row/table-body-row.tsx
@@ -8,7 +8,7 @@ export interface RowProps extends HTMLProps<HTMLTableRowElement> {
 }
 
 const TableBodyRow = forwardRef<HTMLTableRowElement, RowProps>(
-    ({ children, className, isExpanded, style }, ref) => {
+    ({ children, className, isExpanded, style, ...props }, ref) => {
         return (
             <tr
                 className={classNames(
@@ -17,6 +17,7 @@ const TableBodyRow = forwardRef<HTMLTableRowElement, RowProps>(
                 )}
                 ref={ref}
                 style={style}
+                {...props}
             >
                 {children}
             </tr>


### PR DESCRIPTION
## Description

To support `onClick` we need to pass it to the component. We already pass the `HTMLTableRowElement` but not using all props here. Just pass the rest props and it should be fine.