### PR TITLE
feat(Disclosure): Use headless ui disclosure panel props on Disclosur…

### DIFF
--- a/src/components/disclosure/disclosure.tsx
+++ b/src/components/disclosure/disclosure.tsx
@@ -1,17 +1,15 @@
 import {
+    DisclosurePanelProps,
     Disclosure as HeadlessUiDisclosure,
     DisclosureButton as HeadlessUiDisclosureButton,
+    DisclosurePanel as HeadlessUiDisclosurePanel,
 } from "@headlessui/react";
 import React from "react";
 import { ChevronDownIcon } from "../../icons";
 import { classNames } from "../../util/class-names";
 
-interface DisclosurePanelProps extends React.ComponentPropsWithoutRef<"div"> {
-    children: React.ReactNode;
-}
-
-const DisclosurePanel = ({ children, ...props }: DisclosurePanelProps) => {
-    return <HeadlessUiDisclosure.Panel {...props}>{children}</HeadlessUiDisclosure.Panel>;
+const DisclosurePanel = ({ children, ...props }: Omit<DisclosurePanelProps, "ref">) => {
+    return <HeadlessUiDisclosurePanel {...props}>{children}</HeadlessUiDisclosurePanel>;
 };
 
 interface DisclosureButtonProps extends React.ComponentPropsWithoutRef<"button"> {


### PR DESCRIPTION
I need the disclosure panel to take all the headless UI props to implement the expand all/close all button on the Lookup page.

## Description

[Description here]

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [ ] Change is readable and easy to understand
- [ ] Documentation is updated
- [ ] Security impact has been considered
- [ ] Changes validated in runtime