### PR TITLE
 Revert `isIndented` deprecation and document what it's used for

### DIFF
--- a/src/components/navigation/navigation-disclosure-panel.tsx
+++ b/src/components/navigation/navigation-disclosure-panel.tsx
@@ -4,7 +4,11 @@ import { classNames } from "../../util/class-names";
 
 export interface NavigationDisclosurePanelItemProps extends React.ComponentPropsWithoutRef<"div"> {
     isActive?: boolean;
-    /** @deprecated isIndented should no longer be used and will be removed in a future release. */
+    /**
+     * Give this navigation item extra indentation of width consistent with the `LeftIcon` of a `NavigationGroup`.
+     * This should be used if the parent has an icon and the child item does not to make the margins consistent.
+     * i.e. the child item intents on the text of the parent item, not the icon.
+     */
     isIndented?: boolean;
 }
 

--- a/src/components/navigation/navigation.stories.tsx
+++ b/src/components/navigation/navigation.stories.tsx
@@ -90,13 +90,13 @@ export const Default: Story = {
                                 Plans & Billing
                             </Navigation.Disclosure.Button>
                             <Navigation.Disclosure.Panel>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Subscriptions
                                 </Navigation.Disclosure.Panel.Item>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Billing
                                 </Navigation.Disclosure.Panel.Item>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Invoices
                                 </Navigation.Disclosure.Panel.Item>
                             </Navigation.Disclosure.Panel>
@@ -106,13 +106,13 @@ export const Default: Story = {
                                 Settings
                             </Navigation.Disclosure.Button>
                             <Navigation.Disclosure.Panel>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Profile
                                 </Navigation.Disclosure.Panel.Item>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Team
                                 </Navigation.Disclosure.Panel.Item>
-                                <Navigation.Disclosure.Panel.Item>
+                                <Navigation.Disclosure.Panel.Item isIndented>
                                     Sign out
                                 </Navigation.Disclosure.Panel.Item>
                             </Navigation.Disclosure.Panel>


### PR DESCRIPTION
## Description

In a previous PR (https://github.com/abusix/hailstorm/pull/186) the `isIndented` prop was marked as deprecated. It's actually required in order to indent children navigation items underneath navigation groups with icons correctly.

This PR removes the deprecation note, and adds documentation with the prop explaining why it's required and when it should be used.

## Checklist

- [x] Change increases quality
- [ ] Change is validated by tests
- [x] Change is readable and easy to understand
- [x] Documentation is updated
- [x] Security impact has been considered
- [x] Changes validated in runtime
