### PR TITLE
Deploy to GitHub registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 				"bradlc.vscode-tailwindcss",
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
+				"github.vscode-github-actions",
 				"vitest.explorer"
 			]
 		}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ env:
     GH_TOKEN: ${{ secrets.GH_TOKEN }}
     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+permissions:
+    packages: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -26,3 +29,10 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - run: pnpm run build
             - run: pnpm dlx semantic-release
+            
+            # We also release to the github registry, this is because other internal @abusix packages are hosted
+            # there, and pnpm does not let you mix and match registries within a scope
+            - name: Release to Github registry
+              run: |
+                echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
+                pnpm publish --registry=https://npm.pkg.github.com


### PR DESCRIPTION
- **chore(dev): Add Github actions extension to dev container configuration**
- **feat(build): Publish to github in addition to npm**

## Description

We already use the @abusix scope for packages for various private packages. We now have a clash in one of our apps as we are trying to install one of these github packages and hailstorm (via npm) in the same project.
Unfortunately pnpm does not support mixing and matching registries within a single scope. So the most inobtrustive option is simply to publish to both registries.

## Checklist

- [ ] Change increases quality
- [ ] Change is validated by tests
- [x] Change is readable and easy to understand
- [ ] Documentation is updated
- [x] Security impact has been considered
- [ ] Changes validated in runtime
