### PR TITLE
feat(Dialog): add hasCloseButton prop to control close button visibility

### DIFF
--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -107,6 +107,42 @@ export const WithFooterButtons: Story = {
     },
 };
 
+export const WithoutCloseButton: Story = {
+    args: {
+        hasCloseButton: false,
+        footer: <IconFooters />,
+    },
+    argTypes: {
+        footer: hiddenArgControl,
+    },
+    render: ({ children, ...args }) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [isShown, setIsShown] = useState(false);
+        const toggleBtn = () => setIsShown((val) => !val);
+
+        return (
+            <div className="body-font">
+                <button
+                    type="button"
+                    onClick={toggleBtn}
+                    className="bg-neutral-100 px-4 py-2 shadow"
+                >
+                    show Modal (without X button)
+                </button>
+
+                <Dialog
+                    {...args}
+                    footer={<IconFooters onClose={() => setIsShown(false)} />}
+                    isShown={isShown}
+                    onClose={toggleBtn}
+                >
+                    {children}
+                </Dialog>
+            </div>
+        );
+    },
+};
+
 export const WithLongContent: Story = {
     args: {
         children: (

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -16,6 +16,7 @@ export interface DialogProps {
     title?: string;
     onClose?: (submitted: boolean) => void;
     isCloseable?: boolean;
+    hasCloseButton?: boolean;
     className?: string;
     children: React.ReactNode;
     footer?: React.ReactNode | null;
@@ -29,6 +30,7 @@ export const Dialog = ({
     children,
     className,
     isCloseable = true,
+    hasCloseButton = true,
     footer,
     footerPosition = "end",
     onClose,
@@ -91,7 +93,7 @@ export const Dialog = ({
                                     {title}
                                 </HeadlessDialogTitle>
 
-                                {isCloseable && (
+                                {isCloseable && hasCloseButton && (
                                     <IconButton
                                         className="absolute right-0 top-0"
                                         Icon={CrossIcon}


### PR DESCRIPTION
## Summary
Added a new `hasCloseButton` prop to the Dialog component that allows developers to optionally hide the close button (X) in the top-right corner of the dialog.

## Changes
- Added `hasCloseButton` prop to DialogProps interface with boolean type
- Set default value to `true` to maintain backward compatibility  
- Updated close button rendering logic to check both `isCloseable` and `hasCloseButton`
- Added new Storybook story "WithoutCloseButton" to demonstrate the feature

## Motivation
In cases where dialogs already have Cancel/Done buttons in the footer, the X button can be redundant. This change allows developers to remove the visual close button while maintaining the dialog's closeable behavior through other means (backdrop click, ESC key, footer buttons).

## Key Differences from `isCloseable`
- `hasCloseButton={false}`: Only hides the X button visually, dialog remains closeable via other methods
- `isCloseable={false}`: Prevents all closing mechanisms and hides the button

## Breaking Changes
None - fully backward compatible. Existing dialogs will continue to show the close button by default.

## Testing
- ✅ Verified backward compatibility - existing dialogs unchanged
- ✅ Tested new prop in Storybook
- ✅ TypeScript types updated
- ✅ All checks pass (format, lint, type-check, build)

## Example Usage
```tsx
<Dialog
  isShown={isOpen}
  onClose={handleClose}
  hasCloseButton={false}  // Hides the X button
  title="My Dialog"
>
  {/* content */}
</Dialog>
```

🤖 Generated with [Claude Code](https://claude.ai/code)