### PR TITLE
chore(ci): make the release pipeline safe for the beta channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,37 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm run build
+
+            # semantic-release rewrites package.json's version in the workspace when it
+            # publishes, but never commits it (there is no @semantic-release/git plugin).
+            # Comparing the version before and after is therefore how we detect whether a
+            # release actually happened — needed to gate the Github Packages step below.
+            - name: Record version before release
+              id: before
+              run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
             - run: pnpm dlx semantic-release@24
-            
+
+            - name: Record version after release
+              id: after
+              run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
             # We also release to the github registry, this is because other internal @abusix packages are hosted
-            # there, and pnpm does not let you mix and match registries within a scope
+            # there, and pnpm does not let you mix and match registries within a scope.
+            # Skipped when semantic-release published nothing, otherwise this would retry an
+            # already-published version and fail with a 409.
             - name: Release to Github registry
+              if: steps.before.outputs.version != steps.after.outputs.version
               run: |
                 echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
+                # Match the dist-tag semantic-release used on npm. Without this, publishing
+                # from a prerelease branch would move the Github registry's `latest` tag to a
+                # prerelease for the whole beta window.
+                if [ "${GITHUB_REF_NAME}" = "main" ]; then
+                  DIST_TAG="latest"
+                else
+                  DIST_TAG="${GITHUB_REF_NAME}"
+                fi
                 # We disable git checks because semantic release above has bumped the version in the package.json
                 # so we are expecting the git state to be dirty
-                pnpm publish --registry=https://npm.pkg.github.com --no-git-checks
+                pnpm publish --registry=https://npm.pkg.github.com --no-git-checks --tag "${DIST_TAG}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@abusix/hailstorm",
-    "version": "6.0.0-beta.2",
+    "version": "0.0.0",
     "description": "our own design/component library",
     "homepage": "https://github.com/abusix/hailstorm",
     "author": "abusix",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,7 @@
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 import postcss from "rollup-plugin-postcss";
 import terser from "@rollup/plugin-terser";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";


### PR DESCRIPTION
Needed before we can release to the beta channel for the React 19 migration. Creating `beta` from `main` is a push with no releasable commits, so semantic-release no-ops, package.json keeps its committed version, and the ungated Github Packages step then retries an already-published version and fails with a 409. Publishing a prerelease would also have moved the Github registry's `latest` tag to it for the whole beta window, which matters because consuming apps resolve @abusix packages from that registry rather than npm.

- Gate the Github Packages step on whether semantic-release actually published, by comparing package.json's version before and after. The version is rewritten in the workspace but never committed, so the diff is a reliable signal that a release happened.
- Pass the dist-tag matching the branch, so prereleases land on `beta` instead of `latest`.
- Restore "version": "0.0.0", per b63315c which deliberately removed @semantic-release/git. It was hand-edited to 6.0.0-beta.2 in e0f53ce, leaving the field reading as a real version four releases out of date. `0.0.0` is self-evidently a placeholder.
- Use the `with` import attribute in rollup.config.mjs; `assert` was removed in Node 22 and breaks the build there.